### PR TITLE
Fix: Implement proper caching for lottery ticket checks

### DIFF
--- a/backend/src/services/lottery.service.js
+++ b/backend/src/services/lottery.service.js
@@ -91,8 +91,9 @@ class LotteryApiService {
    * @returns {Promise<{data: Object, remainingTTL: number}>} Draw results and cache TTL
    */
   async getDrawResults(drawId, requestId) {
+    const cacheKey = `draw-results-${drawId}`;
     return CacheUtil.getData(
-      `results-${drawId}`,
+      cacheKey,
       () =>
         this._makeApiCall(
           `${this.config.ENDPOINTS.DRAW_RESULTS}?idsorteo=${drawId}`,
@@ -112,8 +113,12 @@ class LotteryApiService {
    * @returns {Promise<Object>} An object describing the ticket result
    */
   async checkTicketNumber(drawId, ticketNumber, requestId) {
-    // 1. Fetch the raw data from the official endpoint
-    const rawData = await this.getTicketInfo(drawId, requestId);
+    // Use cache for ticket info
+    const { data: rawData } = await CacheUtil.getData(
+      `ticket-${drawId}`,
+      () => this.getTicketInfo(drawId, requestId),
+      requestId
+    );
 
     // Safety check
     if (!rawData || !Array.isArray(rawData.compruebe)) {

--- a/backend/src/utils/cache.util.js
+++ b/backend/src/utils/cache.util.js
@@ -122,6 +122,9 @@ class CacheUtil {
     if (key === "results" && data.estadoCelebracionLNAC === true) {
       return 30; // Short TTL during active draw
     }
+    if (key.startsWith("ticket-")) {
+      return 300; // 5 minutes for ticket results
+    }
     return this._DEFAULT_TTL;
   }
 }


### PR DESCRIPTION
## 🔍 Problem
The lottery service wasn't properly utilizing the cache system, causing unnecessary API calls and slower response times for repeated ticket checks.

## 💡 Solution
- Implemented proper caching for ticket info requests
- Standardized cache key format across the service
- Adjusted TTL settings for optimal cache performance

## 🧪 How to Test
1. Make multiple requests to check the same ticket number:
   ```bash
   curl http://localhost:3000/check/{drawId}/{ticketNumber}
   ```
2. Verify in the metrics endpoint that:
   - Cache hits are increasing
   - Response times for subsequent requests are significantly lower
   - The cache hit rate is improving

## 📊 Expected Results
- First request: ~400-500ms
- Subsequent requests (same ticket): ~5-10ms
- Cache metrics should show hits > 0

## 🔍 Additional Notes
- Cache TTL for tickets is set to 5 minutes
- This change doesn't affect the actual lottery results, only improves performance
- No database changes required

## 📝 Related Issues
Closes #[issue_number] (if applicable)